### PR TITLE
Explicitly grant START_ACTIVITIES_FROM_BACKGROUND to com.android.phone.

### DIFF
--- a/data/etc/privapp-permissions-platform.xml
+++ b/data/etc/privapp-permissions-platform.xml
@@ -151,6 +151,7 @@ applications that come with the platform
         <permission name="android.permission.SET_TIME"/>
         <permission name="android.permission.SET_TIME_ZONE"/>
         <permission name="android.permission.SHUTDOWN"/>
+        <permission name="android.permission.START_ACTIVITIES_FROM_BACKGROUND"/>
         <permission name="android.permission.STATUS_BAR"/>
         <permission name="android.permission.STOP_APP_SWITCHES"/>
         <permission name="android.permission.UPDATE_APP_OPS_STATS"/>


### PR DESCRIPTION
It's needed because when we broadcast ACTION_SIM_SLOT_STATUS_CHANGED
we want to allow the receiving app to start an activity from the
background.

The app already has it implicitly, since it has the same shared UID as
com.android.stk which has the permission for unrelated reasons. Making
it explicit makes it less likely it will lose the permission
accidentally re-introducing a subtly bug.

Bug: 132691768
Test: Builds
Change-Id: I85669423e628b4534a3f28efd17947ca2481454e
Merged-In: I85669423e628b4534a3f28efd17947ca2481454e